### PR TITLE
making cli.py runnable

### DIFF
--- a/rein/cli.py
+++ b/rein/cli.py
@@ -1059,3 +1059,7 @@ def select_by_form(candidates, field, form):
        return None
    else:
        click.echo(field + " is required but not in your defaults file")
+
+
+if __name__ == '__main__':
+    cli()


### PR DESCRIPTION
In this way it is possible to run the client without installing it:

```
$ python cli.py
```

Nothing changes for those who follow the tutorial.
