### PR TITLE
Handle + in contact field, fix mnemonic bypass method

### DIFF
--- a/rein/html/js/setup.js
+++ b/rein/html/js/setup.js
@@ -59,9 +59,9 @@ function renderConfirmationPage() {
 function confirmMnemonic() {
     // TODO - Add a retry counter
     mnemonic = sessionStorage.mnemonic.split(' ');
-    wordsToCheck = sessionStorage.wordsToCheck;
+    wordsToCheck = sessionStorage.wordsToCheck.split(',');
     conditions = [];
-    for (var i = 0, len = wordsToCheck; i < len; i++) {
+    for (var i = 0; i < wordsToCheck.length; i++) {
         wordNo = wordsToCheck[i];
         conditions[i] = document.getElementById('word' + wordNo).value == mnemonic[wordNo - 1];
     }
@@ -79,7 +79,7 @@ function submitData() {
     urlEncodedDataPairs = ['name=' + sessionStorage.name, 'contact=' + sessionStorage.contact, 
                            'mediate=' + sessionStorage.mediate, 'mediatorFee=' + sessionStorage.mediatorFee, 
                            'mnemonic=' + sessionStorage.mnemonic];
-    urlEncodedData = urlEncodedDataPairs.join('&').replace(/%20/g, '+');
+    urlEncodedData = urlEncodedDataPairs.join('&').replace(/\+/, '%2B');
     var xhttp = new XMLHttpRequest();
     xhttp.open('POST', '/register-user', true);
     xhttp.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');

--- a/rein/html/js/setup.js
+++ b/rein/html/js/setup.js
@@ -67,7 +67,7 @@ function confirmMnemonic() {
     }
     for (var i = 0; i < conditions.length; i++) {
         if (conditions[i] == false) {
-            errors = "Some of the words you entered are incorrect. Try again.\n";
+            errors = "Some of the words you entered are incorrect. Please try again or restart the setup.";
             document.getElementById('errors').innerText = errors;
             return
         }

--- a/rein/html/setup.html
+++ b/rein/html/setup.html
@@ -15,7 +15,7 @@
         </div>
     </div>
     <div class="row" style="color: red">
-        <div class="col-sm-offset-1 col-sm-6" id="errors">
+        <div class="col-sm-offset-1 col-sm-6" style="padding-bottom: 10px;" id="errors">
         </div>
     </div>
     <div id="ajax-elements">


### PR DESCRIPTION
A + in the contact field was being turned into a space.

Previously a user could bypass the mnemonic confirmation by submitting a blank form. The bug was treating a string as an array which was fixed.