### PR TITLE
Merged with upstream, disabled rating updates, fixed CLI setup issue

### DIFF
--- a/rein/cli.py
+++ b/rein/cli.py
@@ -998,10 +998,8 @@ def sync_core(log, user, key, urls):
                 if len(placements) == 0:
                     upload.append([doc, url])
                 else:
-                    # Also upload all ratings created locally to allow for rating updates
-                    is_own_rating = doc.doc_type == 'rating' and doc.source_url == 'local'
                     for plc in placements:
-                        if Placement.get_remote_document_hash(rein, plc) != doc.doc_hash or is_own_rating:
+                        if Placement.get_remote_document_hash(rein, plc) != doc.doc_hash:
                             upload.append([doc, url])
     
     failed = []

--- a/rein/cli.py
+++ b/rein/cli.py
@@ -28,7 +28,7 @@ from .lib.io import safe_get
 from .lib.script import build_2_of_3, build_mandatory_multisig, check_redeem_scripts
 from .lib.localization import init_localization
 from .lib.transaction import partial_spend_p2sh, spend_p2sh, spend_p2sh_mediator, partial_spend_p2sh_mediator, partial_spend_p2sh_mediator_2
-from .lib.rating import add_rating, get_user_jobs
+from .lib.rating import add_rating, get_user_jobs, get_average_user_ratings
 
 # Import config
 import rein.lib.config as config

--- a/rein/cli.py
+++ b/rein/cli.py
@@ -1057,15 +1057,7 @@ def sync_core(log, user, key, urls):
         answer = safe_get(log, sel_url.format(user.maddr, nonce[url]))
         log.info('nonce cleared for %s' % (url))
 
-    sel_url = "{0}query?owner={1}&query={2}&testnet={3}"
-    ratings = safe_get(log, sel_url.format(url, user.maddr, 'ratings', rein.testnet))
-    if ratings and ratings['result'] != 'error':
-        rein.session.query(Document).filter(Document.doc_type == 'rating').delete()
-        for rating in ratings['ratings']:
-            d = Document(rein, 'rating', rating['value'], sig_verified=True, testnet=rein.testnet)
-            rein.session.add(d)
-            rein.session.commit()
-
+    rein.session.commit()
     click.echo('%s docs checked on %s servers, %s uploads done.' % (len(documents), len(urls), str(succeeded)))
 
 @cli.command()

--- a/rein/lib/document.py
+++ b/rein/lib/document.py
@@ -5,6 +5,7 @@ from sqlalchemy.ext.declarative import declarative_base
 from .validate import filter_valid_sigs, parse_document
 from .order import Order
 from .io import safe_get
+from .util import document_to_dict
 
 Base = declarative_base()
 
@@ -125,16 +126,4 @@ class Document(Base):
         return hashlib.sha256(text).hexdigest()
 
     def to_dict(self):
-        content = self.contents
-        doc = {}
-        # Grab part of the document containing information
-        content = content.split('\n-----BEGIN SIGNATURE-----')[0]
-        # Remove heading
-        content = content.split('\n')[2:]
-        for line in content:
-            key_value = line.split(': ')
-            key = key_value[0]
-            value = key_value[1]
-            doc[key] = value
-
-        return doc
+        return document_to_dict(self.contents)

--- a/rein/lib/rating.py
+++ b/rein/lib/rating.py
@@ -47,7 +47,7 @@ def get_user_jobs(rein, return_dict=False):
     for o in orders:
         setattr(o,'state',STATE[o.get_state(rein, Document)]['past_tense'])
         # Enable rating only for jobs that are completed
-        relevant_states = ['complete, work accepted', 'dispute resolved', 'job awarded'] # For testing 'job awarded'
+        relevant_states = ['complete, work accepted', 'dispute resolved'] # For testing 'job awarded'
         if o.state in relevant_states:
             relevant_orders.append(o)
 

--- a/rein/lib/rating.py
+++ b/rein/lib/rating.py
@@ -1,3 +1,5 @@
+from flask import flash
+
 from .market import assemble_document, sign_and_store_document
 from .document import Document
 from .io import safe_get
@@ -100,7 +102,7 @@ def add_rating(rein, user, testnet, rating, user_msin, job_id, rated_by_msin, co
     store = True
     document = None
     if update_rating:
-    	document = sign_and_store_document(rein, 'rating', document_text, user.daddr, user.dkey, store, update_rating.doc_hash)
+    	flash(u"Ratings cannot currently be updated.")
 
     else:
     	document = sign_and_store_document(rein, 'rating', document_text, user.daddr, user.dkey, store)

--- a/rein/lib/ui.py
+++ b/rein/lib/ui.py
@@ -9,6 +9,7 @@ from .validate import validate_enrollment
 from .user import User, Base
 from .util import unique
 from .document import Document
+from .bitcoinaddress import generate_sin
 import rein.lib.crypto.bip32 as bip32
 
 
@@ -115,6 +116,7 @@ def create_account(rein):
         daddr = bip32.get_delegate_address(key)
         dkey = bip32.get_delegate_private_key(key)
         dxprv = bip32.get_delegate_extended_key(key)
+        msin = generate_sin(maddr)
     else:
         click.echo(highlight('\nTo sign up for Rein you have to put down the mnemonic. Aborting.', False, True))
         quit()
@@ -136,6 +138,7 @@ def create_account(rein):
                  'dxprv': dxprv,
                  'will_mediate': will_mediate,
                  'mediator_fee': mediator_fee,
+                 'msin': msin,
                  'testnet': rein.testnet}
     new_identity = User(user_data)
     rein.session.add(new_identity)

--- a/rein/lib/util.py
+++ b/rein/lib/util.py
@@ -1,3 +1,22 @@
+def document_to_dict(content):
+    """Turns a document's contents into a dict"""
+
+    doc = {}
+    try:
+        # Grab part of the document containing information
+        content = content.split('\n-----BEGIN SIGNATURE-----')[0]
+        # Remove heading
+        content = content.split('\n')[2:]
+        for line in content:
+            key_value = line.split(': ')
+            key = key_value[0]
+            value = key_value[1]
+            doc[key] = value
+
+    except:
+        return {'error': 'unspecified error'}
+
+    return doc
 
 def unique(the_array, key=None):
     """


### PR DESCRIPTION
Rating updates were causing issues with replicated rating documents, when trying to set up an identity using "rein setup", one received an error